### PR TITLE
Re-introduce APIs section

### DIFF
--- a/content/docs/reference/apis/_index.en.md
+++ b/content/docs/reference/apis/_index.en.md
@@ -1,0 +1,13 @@
+---
+title: "APIs"
+linkTitle: "APIs"
+description: "Programming interfaces specifications"
+weight: 60
+---
+
+**RailJSON** is the format used to describe a railway infrastructure, it's
+described in its [JSON schema].
+
+Below are a list of REST APIs implemented by OSRD.
+
+[JSON schema]: https://json-schema.app/view/%23?url=https%3A%2F%2Fraw.githubusercontent.com%2FOpenRailAssociation%2Fosrd%2Fdev%2Ffront%2Fsrc%2Freducers%2Fosrdconf%2Finfra_schema.json

--- a/content/docs/reference/apis/editoast.md
+++ b/content/docs/reference/apis/editoast.md
@@ -1,0 +1,7 @@
+---
+title: "Editoast"
+type: page
+layout: swagger-ui
+params:
+  filename: editoast/openapi.yaml
+---

--- a/content/docs/reference/apis/gateway.md
+++ b/content/docs/reference/apis/gateway.md
@@ -1,0 +1,7 @@
+---
+title: "Gateway"
+type: page
+layout: swagger-ui
+params:
+  filename: gateway/openapi.yaml
+---

--- a/layouts/page/swagger-ui.html
+++ b/layouts/page/swagger-ui.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>{{ .Params.Title }} REST API</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css"/>
+</head>
+<body>
+<div id="swagger-ui"></div>
+<script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js" crossorigin></script>
+<script>
+  window.onload = () => {
+    window.ui = SwaggerUIBundle({
+      url: 'https://raw.githubusercontent.com/OpenRailAssociation/osrd/dev/{{ .Params.params.filename }}',
+      dom_id: '#swagger-ui',
+    });
+  };
+</script>
+</body>
+</html>


### PR DESCRIPTION
It seems like the APIs section has been removed in 3de3e8c95c73. However I found it quite handy to be able to quickly access a webpage describing the API.

It appears like there were two issues with the previous approach: the OpenAPI schema was locally duplicated (making it often times outdated and cumbersome to keep in sync), and the swagger-ui integration needed a dedicated Hugo plugin.

Directly download the OpenAPI schema from GitHub instead of keeping a copy, and use a HTML template for swagger-ui instead of a plugin. This should make it easier to maintain.

* * *

Is this an acceptable approach? Were there other reasons why the APIs section has been dropped in the first place?