### PR TITLE
ci: remove unused railjson schema

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -35,36 +35,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Install GDAL
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gdal-bin
-
-      - name: Clone OSRD repository
-        run: |
-          git clone https://github.com/osrd-project/osrd.git /tmp/osrd
-          mv /tmp/osrd/python/osrd_schemas ./
-
-      - name: Install poetry
-        run: pipx install poetry
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-          cache: poetry
-
-      - name: Install osrd_schemas
-        working-directory: ./osrd_schemas
-        run: poetry install --no-interaction --no-root
-
-      - name: Generate infra and rolling_stock JSON schema
-        run: |
-          mkdir -p public/schemas
-          cd ./osrd_schemas
-          poetry run python -m osrd_schemas.infra > ../public/schemas/infra_schema.json
-          poetry run python -m osrd_schemas.rolling_stock > ../public/schemas/rolling_stock_schema.json
-
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
We are not using the static built json schema files anymore. (Removed [here](https://github.com/OpenRailAssociation/osrd-website/commit/3de3e8c95c73d4b0e18f13e252cb319189838ee4))