### PR TITLE
Roadmap add link to project boards

### DIFF
--- a/content/about/roadmap.en.md
+++ b/content/about/roadmap.en.md
@@ -20,3 +20,7 @@ This roadmap is spread over a couple of years.
 - Revamp train simulation v3.
 
 If you'd like to push for one of these features, or if you have ideas for what OSRD could do in the future, don't hesitate to join the project!
+
+{{% alert title="Note" color="info" %}}
+Tasks that are currently developed and assigned to our team can be found in our project boards [here](https://github.com/orgs/OpenRailAssociation/projects?query=is%3Aopen).
+{{% /alert %}}

--- a/content/about/roadmap.fr.md
+++ b/content/about/roadmap.fr.md
@@ -21,3 +21,6 @@ Cette feuille de route s'étale sur plusieurs années.
 
 Si vous souhaitez pousser l'une de ces fonctionnalités, ou si vous avez des idées sur ce que OSRD pourrait faire à l'avenir, n'hésitez pas à rejoindre le projet !
 
+{{% alert title="Note" color="info" %}}
+Les tâches qui sont actuellement développées et assignées à notre équipe peuvent être trouvées dans nos tableaux [ici](https://github.com/orgs/OpenRailAssociation/projects?query=is%3Aopen).
+{{% /alert %}}


### PR DESCRIPTION
This is to fix the following comment: https://github.com/OpenRailAssociation/technical-committee/pull/190#discussion_r1923445268