### PR TITLE
github: switch to cspell action, warn about changed files only

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -36,9 +36,5 @@ jobs:
         incremental_files_only: true
         use_cspell_files: true
 
-  check_reuse_compliance:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v4
+    - name: REUSE Compliance Check
+      uses: fsfe/reuse-action@v4

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -27,10 +27,14 @@ jobs:
 
         commit_titles | TERM=xterm-color .github/scripts/check-commit-titles.sh
 
+    - run: npm install --include=dev
     - name: Spell check
-      run: |
-        npm install --include=dev
-        npm run spellcheck
+      uses: streetsidesoftware/cspell-action@v6
+      with:
+        config: cspell/cspell.json
+        strict: false
+        incremental_files_only: true
+        use_cspell_files: true
 
   check_reuse_compliance:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Switch to [streetsidesoftware/cspell-action][1] so that:

- Spelling errors are not fatal
- Spelling errors are reported inline

[1]: https://github.com/streetsidesoftware/cspell-action