### PR TITLE
docs: fix REST API docs

### DIFF
--- a/layouts/page/swagger-ui.html
+++ b/layouts/page/swagger-ui.html
@@ -12,7 +12,7 @@
 <script>
   window.onload = () => {
     window.ui = SwaggerUIBundle({
-      url: 'https://raw.githubusercontent.com/OpenRailAssociation/osrd/dev/{{ .Params.params.filename }}',
+      url: 'https://raw.githubusercontent.com/OpenRailAssociation/osrd/dev/{{ .Param "filename" }}',
       dom_id: '#swagger-ui',
     });
   };


### PR DESCRIPTION
Seems like "Params.params" doesn't exist anymore. Use the "Param" (singular) function instead:
https://gohugo.io/methods/page/param/