### PR TITLE
front: fix language toggle dropdown

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -164,7 +164,7 @@ navbar_translucent_over_cover_disable = false
 # Enable to show the side bar menu in its compact state.
 sidebar_menu_compact = false
 # Adds a foldable tree view
-sidebar_menu_foldable = true
+sidebar_menu_foldable = false
 # Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
 sidebar_search_disable = false
 


### PR DESCRIPTION
Comment:
The language toggle dropdown is out of place on the current website (see videos for problem & fix).

Video demonstrations of the problem & solution can be found in this pr: https://github.com/OpenRailAssociation/osrd-website/pull/281

I had a lot of technical difficulty verifying my commits (I think that's why the other pr was closed).
