### PR TITLE
doc: add missing pages to at least translate table of contents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,7 @@ If you need help or want to get in touch you can email us at <contact@osrd.fr>, 
 
 To comply with the [DCO](http://developercertificate.org/), all commits must
 include a Signed-off-by line. You can find more information about this on [our website](https://osrd.fr/en/docs/guides/contribute/contribute-code/commit-conventions/#the-developer-certificate-of-origin).
+
+### Guidelines
+
+Providing both `_index.fr.md` and `_index.en.md` is required to have a table of contents consistent between languages.

--- a/content/docs/railway-wiki/signalling/_index.en.md
+++ b/content/docs/railway-wiki/signalling/_index.en.md
@@ -1,0 +1,18 @@
+---
+title: "Signalling"
+linkTitle: "Signalling"
+weight: 200
+description: Signals, line operation modes and train spacing systems
+---
+
+This section is dedicated to describing the general principles relating to:
+
+- signals
+- line operation modes
+- different train spacing systems
+
+![](/images/docs/railway-wiki/signalling/image-001.png)
+
+The majority of the information in this section is taken from the
+**_[educational document published by the Établissement Public de Sécurité Ferroviaire (EPSF, a public institution responsible for ensuring the safety of railways in France)](./docs/document-pedagogique-signaux-regimes-exploitation-v1.pdf)_**
+published on July 5, 2017.

--- a/content/docs/railway-wiki/signalling/_index.fr.md
+++ b/content/docs/railway-wiki/signalling/_index.fr.md
@@ -2,15 +2,15 @@
 title: "Signalisation"
 linkTitle: "Signalisation"
 weight: 200
-description: Les signaux, régimes d'exploitation des trains, et les systèmes d'espacement des trains
+description: Les signaux, régimes d'exploitation des trains et les systèmes d'espacement des trains
 ---
 
 Cette section est destinée à exposer les principes généraux relatifs :
 - aux signaux
-- aux régimes d’exploitation des lignes (à venir)
+- aux régimes d’exploitation des lignes
 - aux différents systèmes d’espacement des trains
 
 ![](/images/docs/railway-wiki/signalling/image-001.png)
 
-La grande majorité des informations de cette section sont extraites du **_[document pédagogique de l'Établissement Public de
+La majorité des informations de cette section sont extraites du **_[document pédagogique de l'Établissement Public de
 Sécurité Ferroviaire (EPSF)](./docs/document-pedagogique-signaux-regimes-exploitation-v1.pdf)_** édité le 05 juillet 2017.

--- a/content/docs/railway-wiki/signalling/operation-modes/_index.en.md
+++ b/content/docs/railway-wiki/signalling/operation-modes/_index.en.md
@@ -1,0 +1,8 @@
+---
+title: "Line operation modes"
+linkTitle: "Line operation modes"
+weight: 3000
+description:
+---
+
+_Not translated: please select another language_

--- a/content/docs/railway-wiki/signalling/operation-modes/double-track-lines/_index.en.md
+++ b/content/docs/railway-wiki/signalling/operation-modes/double-track-lines/_index.en.md
@@ -1,0 +1,8 @@
+---
+title: "Double-track lines"
+linkTitle: "Double-track lines"
+weight: 20_000
+description:
+---
+
+_Not translated: please select another language._

--- a/content/docs/railway-wiki/signalling/operation-modes/single-track-lines/_index.en.md
+++ b/content/docs/railway-wiki/signalling/operation-modes/single-track-lines/_index.en.md
@@ -1,0 +1,8 @@
+---
+title: "Single-track lines"
+linkTitle: "Single-track lines"
+weight: 10_000
+description:
+---
+
+_Not translated: please select another language._

--- a/content/docs/railway-wiki/signalling/risks/_index.en.md
+++ b/content/docs/railway-wiki/signalling/risks/_index.en.md
@@ -1,0 +1,8 @@
+---
+title: "Railway risks"
+linkTitle: "Railway risks"
+weight: 1000
+description:
+---
+
+_Not translated: please select another language_

--- a/content/docs/railway-wiki/signalling/signals/_index.en.md
+++ b/content/docs/railway-wiki/signalling/signals/_index.en.md
@@ -1,0 +1,8 @@
+---
+title: "Signals"
+linkTitle: "Signals"
+weight: 2000
+description:
+---
+
+_Not translated: please select another language_

--- a/content/docs/railway-wiki/signalling/spacing/_index.en.md
+++ b/content/docs/railway-wiki/signalling/spacing/_index.en.md
@@ -1,0 +1,8 @@
+---
+title: "Train spacing systems"
+linkTitle: "Train spacing systems"
+weight: 4000
+description:
+---
+
+_Not translated: please select another language_

--- a/content/docs/railway-wiki/signalling/spacing/automatic_block_systems/_index.en.md
+++ b/content/docs/railway-wiki/signalling/spacing/automatic_block_systems/_index.en.md
@@ -1,0 +1,7 @@
+---
+title: "Automatic block systems"
+linkTitle: "Automatic block systems"
+weight: 10 000
+---
+
+_Not translated: please select another language._

--- a/content/docs/reference/architecture/services/index.fr.md
+++ b/content/docs/reference/architecture/services/index.fr.md
@@ -1,0 +1,8 @@
+---
+title: "Services"
+linkTitle: "Services"
+weight: 43
+description: OSRD's services architecture
+---
+
+_Non traduit : veuillez sélectionner une autre langue_

--- a/content/docs/reference/design-docs/auth/_index.fr.md
+++ b/content/docs/reference/design-docs/auth/_index.fr.md
@@ -1,0 +1,7 @@
+---
+title: "Authentification et autorisations"
+linkTitle: "Authentification et autorisations"
+weight: 80
+---
+
+_Non traduit : veuillez sélectionner une autre langue._

--- a/content/docs/reference/design-docs/conflict-detection/index.fr.md
+++ b/content/docs/reference/design-docs/conflict-detection/index.fr.md
@@ -1,0 +1,8 @@
+---
+title: "Détection de conflit"
+linkTitle: "Détection de conflit"
+description: "Détecter les planifications horaires irréalistes"
+weight: 45
+---
+
+_Non traduit : veuillez sélectionner une autre langue._

--- a/content/docs/reference/design-docs/editoast-errors/_index.fr.md
+++ b/content/docs/reference/design-docs/editoast-errors/_index.fr.md
@@ -1,0 +1,7 @@
+---
+title: "Gestion d'erreurs dans Editoast"
+linkTitle: "Gestion d'erreurs Editoast"
+weight: 80
+---
+
+_Non traduit : veuillez sélectionner une autre langue._

--- a/content/docs/reference/design-docs/interlocking/_index.en.md
+++ b/content/docs/reference/design-docs/interlocking/_index.en.md
@@ -1,0 +1,8 @@
+---
+title: "Interlocking"
+linkTitle: "Interlocking"
+weight: 40
+description: Description of virtual interlocking
+---
+
+_Not translated: please select another language_

--- a/content/docs/reference/design-docs/scalable-async-rpc/index.fr.md
+++ b/content/docs/reference/design-docs/scalable-async-rpc/index.fr.md
@@ -1,0 +1,7 @@
+---
+title: "Distribution asynchrone et adaptable des tâches entre composants"
+linkTitle: "Distribution asynchrone et adaptable des tâches entre composants"
+weight: 110
+---
+
+_Non traduit : veuillez sélectionner une autre langue._

--- a/content/docs/reference/design-docs/signaling/_index.fr.md
+++ b/content/docs/reference/design-docs/signaling/_index.fr.md
@@ -1,0 +1,8 @@
+---
+title: "Signalisation"
+linkTitle: "Signalisation"
+weight: 43
+description: "Description du modèle de signalisation"
+---
+
+_Non traduit : veuillez sélectionner une autre langue._

--- a/content/docs/reference/design-docs/timetable/index.fr.md
+++ b/content/docs/reference/design-docs/timetable/index.fr.md
@@ -1,0 +1,8 @@
+---
+title: "Timetable v2"
+linkTitle: "Timetable v2"
+weight: 60
+description: "Description des évolution des nouveaux modèles **timetable** et **train schedule**"
+---
+
+_Non traduit : veuillez sélectionner une autre langue._

--- a/content/docs/reference/design-docs/train-sim-v3/_index.en.md
+++ b/content/docs/reference/design-docs/train-sim-v3/_index.en.md
@@ -2,7 +2,7 @@
 title: "Train simulation v3"
 linkTitle: "Train simulation v3"
 description: "Modeling and API design of train simulations"
-weight: 45
+weight: 46
 ---
 
 {{% pageinfo color="warning" %}}

--- a/content/docs/reference/design-docs/train-sim-v3/_index.fr.md
+++ b/content/docs/reference/design-docs/train-sim-v3/_index.fr.md
@@ -1,0 +1,8 @@
+---
+title: "Calcul de marche v3"
+linkTitle: "Calcul de marche v3"
+description: "Modèle et design d'API pour les calculs de marche"
+weight: 46
+---
+
+_Non traduit : veuillez sélectionner une autre langue._


### PR DESCRIPTION
Also very minor changes for consistency.

It was hard to locate a correct spot for [upcoming German signaling documentation](https://github.com/OpenRailAssociation/osrd/issues/12621) without it.

